### PR TITLE
Search for bootable partitions on both SD and eMMC

### DIFF
--- a/meta-fixes/recipes-bsp/u-boot/u-boot/0001-Search-for-bootable-partitions-on-both-SD-and-eMMC.patch
+++ b/meta-fixes/recipes-bsp/u-boot/u-boot/0001-Search-for-bootable-partitions-on-both-SD-and-eMMC.patch
@@ -1,0 +1,38 @@
+From 86cc560ff9a6578326532e277d987e24661e5f04 Mon Sep 17 00:00:00 2001
+From: Jussi Laako <jussi.laako@linux.intel.com>
+Date: Fri, 26 Feb 2016 14:58:32 +0200
+Subject: [PATCH] Search for bootable partitions on both SD and eMMC
+
+On BeagleBone Black, first attempt to boot from microSD and then from
+eMMC if not available.
+
+Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>
+---
+ include/configs/ti_armv7_common.h | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/include/configs/ti_armv7_common.h b/include/configs/ti_armv7_common.h
+index 199612b..ece87ab 100644
+--- a/include/configs/ti_armv7_common.h
++++ b/include/configs/ti_armv7_common.h
+@@ -60,7 +60,16 @@
+ #define DEFAULT_MMC_TI_ARGS \
+ 	"mmcdev=0\0" \
+ 	"mmcrootfstype=ext4 rootwait\0" \
+-	"finduuid=part uuid mmc 0:2 uuid\0" \
++	"findsduuid=part uuid mmc 0:2 sduuid\0" \
++	"findemmcuuid=part uuid mmc 1:2 emmcuuid\0" \
++	"finduuid=if run findsduuid; then "\
++		"echo \"Boot from microSD\"; "\
++		"setenv uuid ${sduuid}; " \
++	"else " \
++		"run findemmcuuid; " \
++		"echo \"Boot from eMMC\"; " \
++		"setenv uuid ${emmcuuid}; " \
++	"fi;\0" \
+ 	"args_mmc=run finduuid;setenv bootargs console=${console} " \
+ 		"${optargs} " \
+ 		"root=PARTUUID=${uuid} rw " \
+-- 
+2.7.0
+

--- a/meta-fixes/recipes-bsp/u-boot/u-boot_2016.01.bbappend
+++ b/meta-fixes/recipes-bsp/u-boot/u-boot_2016.01.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/u-boot:"
+
+SRC_URI_append = " file://0001-Search-for-bootable-partitions-on-both-SD-and-eMMC.patch"


### PR DESCRIPTION
On BeagleBone Black, first attempt to boot from microSD and then from
eMMC if not available.

Fixes: IOTOS-1362

Signed-off-by: Jussi Laako jussi.laako@linux.intel.com
