### PR TITLE
systemd: wait for udev settle in systemd-networkd

### DIFF
--- a/meta-fixes/recipes-core/systemd/systemd/0001-systemd-networkd.service-wait-for-udev-to-settle.patch
+++ b/meta-fixes/recipes-core/systemd/systemd/0001-systemd-networkd.service-wait-for-udev-to-settle.patch
@@ -1,0 +1,30 @@
+From ecc712dca90b3c1a86d033d16a590fd794d7d92c Mon Sep 17 00:00:00 2001
+From: Jussi Laako <jussi.laako@linux.intel.com>
+Date: Mon, 14 Mar 2016 16:07:32 +0200
+Subject: [PATCH] systemd-networkd.service: wait for udev to settle
+
+In order to make USB networking start reliably at boot time, wait udev
+to settle before launching. Makes results of network-online.target
+consistent.
+
+Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>
+---
+ units/systemd-networkd.service.m4.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/units/systemd-networkd.service.m4.in b/units/systemd-networkd.service.m4.in
+index 27d4d58..e4727c1 100644
+--- a/units/systemd-networkd.service.m4.in
++++ b/units/systemd-networkd.service.m4.in
+@@ -12,7 +12,7 @@ ConditionCapability=CAP_NET_ADMIN
+ DefaultDependencies=no
+ # dbus.service can be dropped once on kdbus, and systemd-udevd.service can be
+ # dropped once tuntap is moved to netlink
+-After=systemd-udevd.service dbus.service network-pre.target systemd-sysusers.service systemd-sysctl.service
++After=systemd-udev-settle.service dbus.service network-pre.target systemd-sysusers.service systemd-sysctl.service
+ Before=network.target multi-user.target shutdown.target
+ Conflicts=shutdown.target
+ Wants=network.target
+-- 
+2.7.0
+

--- a/meta-fixes/recipes-core/systemd/systemd_229.bbappend
+++ b/meta-fixes/recipes-core/systemd/systemd_229.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI_append = " file://0001-systemd-networkd.service-wait-for-udev-to-settle.patch"


### PR DESCRIPTION
In order to make USB networking start reliably at boot time, wait
udev to settle before launching systemd-network. Makes results of
network-online.target consistent.

Signed-off-by: Jussi Laako jussi.laako@linux.intel.com
