### PR TITLE
meta-java: Do not use absolute paths when bootstrapping

### DIFF
--- a/meta-fixes/recipes-core/cacao/cacao-initial-native_0.98.bbappend
+++ b/meta-fixes/recipes-core/cacao/cacao-initial-native_0.98.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI_append = "file://cacao-0.9.8-do_not_rely_on_absolute_paths.patch"

--- a/meta-fixes/recipes-core/cacao/files/cacao-0.9.8-do_not_rely_on_absolute_paths.patch
+++ b/meta-fixes/recipes-core/cacao/files/cacao-0.9.8-do_not_rely_on_absolute_paths.patch
@@ -1,0 +1,31 @@
+java.in: Do not use hardcode paths
+
+Cacao uses hardcoded paths to various files, if these paths are not
+provided. This causes issues when sharing sstate with otherwise
+identical workers, if build time paths are not identical.
+
+Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>
+
+---
+ cacao-0.98/src/scripts/java.in | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git cacao-0.98/src/scripts/java.in cacao-0.98/src/scripts/java.in
+index 8a402e4..1738897 100644
+--- cacao-0.98/src/scripts/java.in
++++ cacao-0.98/src/scripts/java.in
+@@ -32,4 +32,10 @@
+ ##
+ ## $Id: java.in 5659 2006-10-04 10:37:09Z twisti $
+
+-exec cacao ${1+"$@"}
++SH_DIR=`dirname "$0"`
++CURRENT_DIR=`cd "${SH_DIR}" && pwd`
++PARENT_DIR=`dirname ${CURRENT_DIR}`
++export BOOTCLASSPATH="${PARENT_DIR}/share/cacao-initial/vm.zip:${PARENT_DIR}/share/classpath-initial/glibj.zip"
++
++LIBRARY_PATH="-Djava.library.path=${PARENT_DIR}/lib/classpath-initial"
++exec cacao ${LIBRARY_PATH} ${1+"$@"}
++
+--
+2.7.4

--- a/meta-fixes/recipes-core/ecj/ecj-initial-native.bbappend
+++ b/meta-fixes/recipes-core/ecj/ecj-initial-native.bbappend
@@ -1,0 +1,13 @@
+do_compile() {
+  # Create the start script
+  echo "#!/bin/sh" > ecj-initial
+
+  # get absolute path to parent directory, and use that as base path for the jar
+  echo "SH_DIR=\`dirname "\$0"\`" >> ecj-initial
+  echo "CURRENT_DIR=\`cd "\${SH_DIR}" && pwd\`" >> ecj-initial
+  echo "PARENT_DIR=\`dirname \${CURRENT_DIR}\`" >> ecj-initial
+
+  echo "ECJ_JAR=\${PARENT_DIR}/share/java/${JAR}" >> ecj-initial
+  echo "RUNTIME=java-initial" >> ecj-initial
+  cat ecj-initial.in >> ecj-initial
+}


### PR DESCRIPTION
This is a test build. The changes will be merged in the devkit upstream once everything passes CI & reviews.

Both cacao-initial-native and ecj-initial-native use hardcoded absolute
paths to various files. Normally this is not an issue, but it makes it
difficult to share sstate between otherwise identical workers, if the
file paths are not identical.

This is fixed by forming the paths at runtime, which allows using the
files in different workers with different folders.

Signed-off-by: Erkka Kääriä erkka.kaaria@intel.com
