### PR TITLE
Add current folder to perl search path

### DIFF
--- a/meta-fixes/recipes-connectivity/openssl/files/fix-find-path.patch
+++ b/meta-fixes/recipes-connectivity/openssl/files/fix-find-path.patch
@@ -1,0 +1,16 @@
+diff --git a/util/perlpath.pl b/util/perlpath.pl
+index a1f236b..042e6aa 100755
+--- a/util/perlpath.pl
++++ b/util/perlpath.pl
+@@ -4,6 +4,8 @@
+ # line in all scripts that rely on perl.
+ #
+ 
++use lib ".";
++
+ require "find.pl";
+ 
+ $#ARGV == 0 || print STDERR "usage: perlpath newpath  (eg /usr/bin)\n";
+-- 
+2.9.3
+

--- a/meta-fixes/recipes-connectivity/openssl/openssl_%.bbappend
+++ b/meta-fixes/recipes-connectivity/openssl/openssl_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " file://fix-find-path.patch"


### PR DESCRIPTION
Add current folder to perl search path in perlpath.pl to enable it to
find find.pl in the same folder. Fixes build at least on Debian with
perl-5.22.

Signed-off-by: Jussi Laako jussi.laako@linux.intel.com
